### PR TITLE
refactor currentUser

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,7 +21,7 @@ import "bootstrap/dist/css/bootstrap.css";
 import "react-toastify/dist/ReactToastify.css";
 
 function App() {
-  const { data: currentUser } = useCurrentUser();
+  const currentUser = useCurrentUser();
 
   return (
     <BrowserRouter>

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -5,7 +5,7 @@ import { useCurrentUser, useLogout } from "main/utils/currentUser";
 import { useSystemInfo } from "main/utils/systemInfo";
 
 export default function BasicLayout({ children }) {
-  const { data: currentUser } = useCurrentUser();
+  const currentUser = useCurrentUser();
   const { data: systemInfo } = useSystemInfo();
 
   const doLogout = useLogout().mutate;

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -5,7 +5,7 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
 import { Inspector } from "react-inspector";
 const ProfilePage = () => {
-  const { data: currentUser } = useCurrentUser();
+  const currentUser = useCurrentUser();
 
   if (!currentUser.loggedIn) {
     return <p>Not logged in.</p>;

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -31,7 +31,7 @@ const ProfilePage = () => {
         </Col>
       </Row>
       <Row className="text-left">
-        <Inspector data={currentUser.root} />
+        <Inspector data={currentUser} />
       </Row>
     </BasicLayout>
   );

--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 
 export function useCurrentUser() {
   let rolesList = ["ERROR_GETTING_ROLES"];
-  return useQuery(
+  const queryResults = useQuery(
     "current user",
     async () => {
       try {
@@ -24,6 +24,7 @@ export function useCurrentUser() {
       initialData: { loggedIn: false, root: null, initialData: true },
     },
   );
+  return queryResults.data;
 }
 
 export function useLogout() {
@@ -38,17 +39,7 @@ export function useLogout() {
 }
 
 export function hasRole(currentUser, role) {
-  // The following hack is because there is some bug in terms of the
-  // shape of the data returned by useCurrentUser.  Is there a separate
-  // data level, or not?
-
-  // We will file an issue to track that down and then remove this hack
-
   if (currentUser == null) return false;
-
-  if (currentUser.data?.root?.rolesList) {
-    return currentUser.data.root.rolesList.includes(role);
-  }
 
   return currentUser.root?.rolesList?.includes(role);
 }

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -34,9 +34,13 @@ describe("utils/currentUser tests", () => {
       const restoreConsole = mockConsole();
 
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
-      await waitFor(() => result.current.isSuccess);
+      await waitFor(() =>
+        expect(queryClient.getQueryState("current user").status).toBe(
+          "success",
+        ),
+      );
 
-      expect(result.current.data).toEqual({
+      expect(result.current).toEqual({
         loggedIn: false,
         root: null,
         initialData: true,
@@ -71,9 +75,13 @@ describe("utils/currentUser tests", () => {
 
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
-      await waitFor(() => result.current.isFetched);
+      await waitFor(() =>
+        expect(queryClient.getQueryState("current user").status).toBe(
+          "success",
+        ),
+      );
 
-      expect(result.current.data).toEqual(currentUserFixtures.userOnly);
+      expect(result.current).toEqual(currentUserFixtures.userOnly);
       queryClient.clear();
     });
 
@@ -91,13 +99,17 @@ describe("utils/currentUser tests", () => {
       const restoreConsole = mockConsole();
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
-      await waitFor(() => result.current.isFetched);
+      await waitFor(() =>
+        expect(queryClient.getQueryState("current user").status).toBe(
+          "success",
+        ),
+      );
       expect(console.error).toHaveBeenCalled();
       const errorMessage = console.error.mock.calls[0][0];
       expect(errorMessage).toMatch(/Error invoking axios.get:/);
       restoreConsole();
 
-      expect(result.current.data).toEqual({
+      expect(result.current).toEqual({
         initialData: true,
         loggedIn: false,
         root: null,
@@ -120,7 +132,11 @@ describe("utils/currentUser tests", () => {
       const restoreConsole = mockConsole();
       const { result } = renderHook(() => useCurrentUser(), { wrapper });
 
-      await waitFor(() => result.current.isFetched);
+      await waitFor(() =>
+        expect(queryClient.getQueryState("current user").status).toBe(
+          "success",
+        ),
+      );
       expect(console.error).toHaveBeenCalled();
       const errorMessage = console.error.mock.calls[0][0];
       expect(errorMessage).toMatch(/Error getting roles: /);
@@ -130,7 +146,7 @@ describe("utils/currentUser tests", () => {
         loggedIn: true,
         root: { ...apiResult, rolesList: ["ERROR_GETTING_ROLES"] },
       };
-      expect(result.current.data).toEqual(expectedResult);
+      expect(result.current).toEqual(expectedResult);
       queryClient.clear();
     });
   });
@@ -216,25 +232,5 @@ describe("utils/currentUser tests", () => {
         ),
       ).toBeTruthy();
     });
-
-    test("hasRole returns correct values when data is in currentUser", async () => {
-      const currentUser = { data: { root: { rolesList: ["ROLE_USER"] } } };
-      expect(hasRole(currentUser, "ROLE_USER")).toBeTruthy();
-      expect(hasRole(currentUser, "ROLE_ADMIN")).toBeFalsy();
-    });
-
-    test("hasRole falls back correctly with various data missing", async () => {
-      expect(hasRole(null, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({}, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ data: null }, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ data: { root: null } }, "ROLE_USER")).toBeFalsy();
-      expect(
-        hasRole({ data: { root: { rolesList: null } } }, "ROLE_USER"),
-      ).toBeFalsy();
-      expect(
-        hasRole({ data: { root: { rolesList: [] } } }, "ROLE_USER"),
-      ).toBeFalsy();
-    });
-    expect(hasRole({ root: { rolesList: null } })).toBeFalsy();
   });
 });


### PR DESCRIPTION
In this PR, we apply @Division7 's change to useCurrentUser from proj-frontiers to this code base.

The original PR is this one: https://github.com/ucsb-cs156/proj-frontiers/pull/198

The current PR places `useCurrentUser()`'s `useQuery()` call inside of a variable so that we only return the data. This makes `useCurrentUser` easier to use, at the cost of hiding the query status.   

