### PR TITLE
Improving Integration Test Speed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,108 @@
       </dependencies>
       <build>
         <plugins>
+          <!-- Check for frontend changes and set skip property -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>check-frontend-changes</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <!-- Check if frontend directory exists and determine if rebuild is needed -->
+                    <condition property="frontend.skip" value="false" else="true">
+                      <and>
+                        <!-- Frontend directory must exist -->
+                        <available file="${project.basedir}/frontend" type="dir"/>
+                        <or>
+                          <!-- Check if node_modules doesn't exist -->
+                          <not>
+                            <available file="${project.basedir}/frontend/node_modules" type="dir"/>
+                          </not>
+                          <!-- Check if build directory doesn't exist -->
+                          <not>
+                            <available file="${project.basedir}/frontend/build" type="dir"/>
+                          </not>
+                          <!-- Check if package.json exists and is newer than node_modules directory -->
+                          <and>
+                            <available file="${project.basedir}/frontend/package.json"/>
+                            <available file="${project.basedir}/frontend/node_modules" type="dir"/>
+                            <not>
+                              <uptodate targetfile="${project.basedir}/frontend/node_modules">
+                                <srcfiles file="${project.basedir}/frontend/package.json"/>
+                              </uptodate>
+                            </not>
+                          </and>
+                          <!-- Check if package-lock.json exists and is newer than node_modules -->
+                          <and>
+                            <available file="${project.basedir}/frontend/package-lock.json"/>
+                            <available file="${project.basedir}/frontend/node_modules" type="dir"/>
+                            <not>
+                              <uptodate targetfile="${project.basedir}/frontend/node_modules">
+                                <srcfiles file="${project.basedir}/frontend/package-lock.json"/>
+                              </uptodate>
+                            </not>
+                          </and>
+                          <!-- Check if source files are newer than build directory -->
+                          <and>
+                            <available file="${project.basedir}/frontend/src" type="dir"/>
+                            <available file="${project.basedir}/frontend/build" type="dir"/>
+                            <not>
+                              <uptodate targetfile="${project.basedir}/frontend/build">
+                                <srcfiles dir="${project.basedir}/frontend/src" includes="**/*"/>
+                              </uptodate>
+                            </not>
+                          </and>
+                          <!-- Check if public files are newer than build directory -->
+                          <and>
+                            <available file="${project.basedir}/frontend/public" type="dir"/>
+                            <available file="${project.basedir}/frontend/build" type="dir"/>
+                            <not>
+                              <uptodate targetfile="${project.basedir}/frontend/build">
+                                <srcfiles dir="${project.basedir}/frontend/public" includes="**/*"/>
+                              </uptodate>
+                            </not>
+                          </and>
+                        </or>
+                      </and>
+                    </condition>
+
+                    <!-- Log the decision -->
+                    <condition property="build.message"
+                               value="Frontend changes detected - will rebuild"
+                               else="No frontend changes detected - skipping npm build">
+                      <equals arg1="${frontend.skip}" arg2="false"/>
+                    </condition>
+                    <echo message="${build.message}" level="info" />
+                  </target>
+                  <exportAntProperties>true</exportAntProperties>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>copy-frontend-build</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <copy todir="${project.build.outputDirectory}/public" failonerror="false">
+                      <fileset dir="${project.basedir}/frontend/build" />
+                    </copy>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Frontend build plugin - only runs when changes detected -->
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
@@ -413,6 +515,7 @@
             <configuration>
               <workingDirectory>frontend</workingDirectory>
               <installDirectory>${project.build.directory}</installDirectory>
+              <skip>${frontend.skip}</skip>
             </configuration>
             <executions>
               <execution>
@@ -441,25 +544,6 @@
                 <configuration>
                   <arguments>run build</arguments>
                 </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <version>3.0.0</version>
-            <executions>
-              <execution>
-                <phase>generate-resources</phase>
-                <configuration>
-                  <target>
-                    <copy todir="${project.build.outputDirectory}/public">
-                      <fileset dir="${project.basedir}/frontend/build" />
-                    </copy>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,7 @@
             <executions>
               <execution>
                 <id>check-frontend-changes</id>
-                <phase>validate</phase>
+                <phase>initialize</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,10 @@
                           <not>
                             <available file="${project.basedir}/frontend/build" type="dir"/>
                           </not>
+                          <!-- Check if output build exists -->
+                          <not>
+                            <available file="${project.build.outputDirectory}/public" type="dir"/>
+                          </not>
                           <!-- Check if package.json exists and is newer than node_modules directory -->
                           <and>
                             <available file="${project.basedir}/frontend/package.json"/>
@@ -464,13 +468,13 @@
                               </uptodate>
                             </not>
                           </and>
-                          <!-- Check if public files are newer than build directory -->
+                          <!-- Check if build files are newer than public directory -->
                           <and>
-                            <available file="${project.basedir}/frontend/public" type="dir"/>
+                            <available file="${project.build.outputDirectory}/public" type="dir"/>
                             <available file="${project.basedir}/frontend/build" type="dir"/>
                             <not>
-                              <uptodate targetfile="${project.basedir}/frontend/build">
-                                <srcfiles dir="${project.basedir}/frontend/public" includes="**/*"/>
+                              <uptodate targetfile="${project.build.outputDirectory}/public">
+                                <srcfiles dir="${project.basedir}/frontend/build" includes="**/*"/>
                               </uptodate>
                             </not>
                           </and>
@@ -492,7 +496,7 @@
 
               <execution>
                 <id>copy-frontend-build</id>
-                <phase>generate-resources</phase>
+                <phase>process-resources</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>


### PR DESCRIPTION
In this PR, I update the pom.xml to only run `npm ci` and `npm run build` when there have been changes to files in the frontend, as well as `package.json` and `package-lock.json`

Basis of changes came from this chat: https://claude.ai/share/36f6a20d-11db-4d5f-9daa-87cc154e90bd

Identical to: https://github.com/ucsb-cs156-s25/STARTER-team02/pull/78

Added to proj-frontiers