### PR TITLE
Remove @storybook/addon-essentials

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -3,7 +3,6 @@ const config = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
     "@storybook/addon-links",
-    "@storybook/addon-essentials",
   ],
   framework: {
     name: '@storybook/react-vite',


### PR DESCRIPTION
In this PR, we remove the storybook addon `"@storybook/addon-essentials"` from the `frontend/.storybook/main.js` configuration file, because it is no longer installed.