### PR TITLE
pc - add -ntp and -B to all mvn commands

### DIFF
--- a/.github/workflows/02-gh-pages-rebuild-part-1.yml
+++ b/.github/workflows/02-gh-pages-rebuild-part-1.yml
@@ -53,7 +53,7 @@ jobs:
          java-version-file: ./.java-version
   
     - name: Build javadoc
-      run: mvn -DskipTests javadoc:javadoc
+      run: mvn -ntp -B -DskipTests javadoc:javadoc
 
     - name: Upload to artifacts
       uses: actions/upload-artifact@v4
@@ -131,7 +131,7 @@ jobs:
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report verify
+      run: mvn -ntp -B test jacoco:report verify
 
     - name: Upload to artifacts
       uses: actions/upload-artifact@v4
@@ -184,7 +184,7 @@ jobs:
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn test pitest:mutationCoverage -DmutationThreshold=100 
+      run: mvn -ntp -B test pitest:mutationCoverage -DmutationThreshold=100 
 
     - name: Upload Pitest History to Artifacts
       if: always() # always upload artifacts, even if tests fail
@@ -316,8 +316,8 @@ jobs:
          java-version-file: ./.java-version
 
     - name: Build javadoc
-      run: mvn -DskipTests javadoc:javadoc
- 
+      run: mvn -ntp -B -DskipTests javadoc:javadoc
+
     - name: Upload javadoc to Artifacts
       if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v4
@@ -421,7 +421,7 @@ jobs:
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report verify
+      run: mvn -ntp -B test jacoco:report verify
  
     - name: Upload to artifacts
       uses: actions/upload-artifact@v4
@@ -488,7 +488,7 @@ jobs:
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn test pitest:mutationCoverage -DmutationThreshold=100 
+      run: mvn -ntp -B test pitest:mutationCoverage -DmutationThreshold=100 
   
     - name: Debugging output after mvn pitest ...
       run: |

--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -27,5 +27,5 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test 
+      run: mvn  -ntp -B test 
       

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report verify
+      run: mvn -ntp -B test jacoco:report verify
 
     - name: Get PR number
       id: get-pr-num

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -52,7 +52,7 @@ jobs:
         [ -f "$historyFile" ] && cp $historyFile target/pit-history/history.bin
 
     - name: Build with Maven
-      run: mvn -B test 
+      run: mvn -ntp -B test 
     - name: Pitest
       run: mvn pitest:mutationCoverage -DmutationThreshold=100 
     - name: Upload Pitest History to Artifacts

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -36,7 +36,7 @@ jobs:
          distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
          java-version-file: ./.java-version
     - name: Build with Maven
-      run: mvn -B test 
+      run: mvn -ntp -B test 
     
     # Note that we DO NOT download history in this job;
     # this job is intended as a "reset" of the history each time the 

--- a/.github/workflows/40-check-production-build.yml
+++ b/.github/workflows/40-check-production-build.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Build with Maven
       env:
         PRODUCTION: true
-      run: mvn -DskipTests clean dependency:list install
+      run: mvn -ntp -B -DskipTests clean dependency:list install
 
   

--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -30,7 +30,7 @@ jobs:
          java-version-file: ./.java-version
   
     - name: Build javadoc
-      run: mvn -DskipTests javadoc:javadoc
+      run: mvn -ntp -B -DskipTests javadoc:javadoc
 
     - name: Deploy 🚀    
       if: always() # always upload artifacts, even if tests fail

--- a/.github/workflows/58-javadoc-pr.yml
+++ b/.github/workflows/58-javadoc-pr.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Build javadoc
       run: |
          mkdir -p target/reports/apidocs
-         mvn -DskipTests javadoc:javadoc
+         mvn -ntp -B -DskipTests javadoc:javadoc
  
     - name: Deploy 🚀    
       if: always() # always upload artifacts, even if tests fail


### PR DESCRIPTION
-ntp is 'no transfer progress' and makes logs easier to read 
-B makes output of logs easier to read also